### PR TITLE
Persistence volumes module

### DIFF
--- a/persistence-volumes/main.tf
+++ b/persistence-volumes/main.tf
@@ -1,0 +1,16 @@
+resource "aws_volume_attachment" "this_volume_attachment" {
+  count = length(var.volumes)
+
+  device_name = var.volumes[count.index].device_name
+  volume_id   = aws_ebs_volume.this_volume[count.index].id
+  instance_id = var.volumes[count.index].instance_id
+}
+
+resource "aws_ebs_volume" "this_volume" {
+  count = length(var.volumes)
+
+  availability_zone = var.volumes[count.index].availability_zone
+  size              = var.volumes[count.index].size
+
+  tags = var.volumes[count.index].volume_tags
+}

--- a/persistence-volumes/outputs.tf
+++ b/persistence-volumes/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "List of IDs of instances"
+  value       = aws_volume_attachment.this_volume_attachment.*.instance_id
+}
+
+output "volume_id" {
+  description = "List of volumes IDs"
+  value       = aws_volume_attachment.this_volume_attachment.*.volume_id
+}
+
+output "device_name" {
+  description = "List of devices names"
+  value       = aws_volume_attachment.this_volume_attachment.*.device_name
+}

--- a/persistence-volumes/vars.tf
+++ b/persistence-volumes/vars.tf
@@ -1,0 +1,13 @@
+variable "volumes" {
+  description = "List of volumes"
+  default     = null
+  type        = list(object(
+                  {
+                    instance_id = string
+                    availability_zone = string
+                    device_name = string
+                    size        = string
+                    volume_tags = map(string)
+                  }
+                ))
+}


### PR DESCRIPTION
Add module to create volumes using volume attachments.

This approach was selected over using `ebs_block_device` from ec2 instances module, since changing that attribute will force instance recreation.